### PR TITLE
IN 1127 - Handle missing fund_distribution entries with empty strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 .DS_Store
 output/

--- a/tests/test_polines.py
+++ b/tests/test_polines.py
@@ -95,6 +95,26 @@ def test_get_total_price_from_fund_distribution_no_amounts_or_sums_returns_unit_
     ) == Decimal("1.23")
 
 
+def test_get_total_price_from_fund_distribution_contains_empty_string_values():
+    price = Decimal("4.56")
+    fund_distribution = [
+        {
+            "amount": {
+                "currency": {},
+                "sum": "",
+            },
+            "fund_code": {
+                "desc": "",
+                "value": "",
+            },
+        },
+    ]
+    assert (
+        po.get_total_price_from_fund_distribution(fund_distribution, unit_price=price)
+        == price
+    )
+
+
 def test_get_total_price_from_fund_distribution_sums_fund_amounts():
     funds = [
         {"fund_code": {"value": "amount-is-zero"}, "amount": {"sum": "0.00"}},


### PR DESCRIPTION
### Purpose and background context

PO lines were pulled from Alma where the `fund_distribution` node in the object contained a fund with empty strings for values like `amount.sum`. This threw an error when attemping to convert to a `Decimal`.

Example from PO line retrieved from Alma:

```json
"fund_distribution": [
  {
    "amount": {
      "sum": "",
      "currency": {}
    },
    "fund_code": {
      "value": "",
      "desc": ""
    }
  }
],
```

Default behavior in other situations is to return `$0.00` when a price cannot be determined from the PO line, which will extend to this scenario.

How this addresses that need:
* `get_total_price_from_fund_distribution()` is updated to handle a fund entry with empty strings, and treat them as `$0.00`

### How can a reviewer manually see the effects of these changes?

1- Set Dev1 admin credentials

2- Set **production** credentials for `ALMA_API_URL` and `ALMA_API_READ_KEY` in shell (these were retrieved from SSM paramters and Secrets)

3- The following invocation will send a `ccslips` email to `ehanson@mit.edu` (currently the only configured email address in Dev1 this will successfully send to):

```shell
pipenv run ccslips --verbose -s ehanson@mit.edu -r ehanson@mit.edu -d 2024-12-13
```

Formerly this was failing, because one of these entries would throw an exception when `fund_distribution` contained funds with empty strings.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Emails will successfully generate with '$0.00' reported when the fund distribution information is empty strings

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1127

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes
